### PR TITLE
main.go: Don't skip first '.pure-table' tr first-child

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 
 func getFilesInfo(d *goquery.Document) []fileInfo {
 	files := []fileInfo{}
-	d.Find(".pure-table tr:not(:first-child)").Each(func(j int, l *goquery.Selection) {
+	d.Find(".pure-table tr").Each(func(j int, l *goquery.Selection) {
 		f := fileInfo{}
 		rows := l.Find("td")
 		rows.Each(func(i int, s *goquery.Selection) {


### PR DESCRIPTION
  I ran across this when running:  apk-file host
  "bind-utils" was contained in the first ".pure-table tbody tr" elements